### PR TITLE
Fix portfolio manager binding

### DIFF
--- a/src/Server/Server.cpp
+++ b/src/Server/Server.cpp
@@ -1393,7 +1393,7 @@ PYBIND11_MODULE(Server, m) {
 		.def("reset_user_portfolio", &IPortfolioManager::reset_user_portfolio, py::arg("user_id"))
 		.def("add_to_security", &IPortfolioManager::add_to_security, py::arg("user_id"), py::arg("security_1"), py::arg("addition_1"))
 		.def("multiply_to_security", &IPortfolioManager::multiply_to_security, py::arg("user_id"), py::arg("security_1"), py::arg("multiplier_1"))
-		.def("multiply_to_security_if_negative", &IPortfolioManager::multiply_to_security, py::arg("user_id"), py::arg("security_1"), py::arg("multiplier_1"))
+                .def("multiply_to_security_if_negative", &IPortfolioManager::multiply_to_security_if_negative, py::arg("user_id"), py::arg("security_1"), py::arg("multiplier_1"))
 		.def("add_to_two_securities", &IPortfolioManager::add_to_two_securities, py::arg("user_id"), py::arg("security_1"), py::arg("addition_1"), py::arg("security_2"), py::arg("addition_2"))
 		.def("multiply_and_add_1_to_2", &IPortfolioManager::multiply_and_add_1_to_2, py::arg("user_id"), py::arg("security_1"), py::arg("security_2"), py::arg("multiply"))
 		.def("multiply_and_add_1_to_2_and_set_1", &IPortfolioManager::multiply_and_add_1_to_2_and_set_1,


### PR DESCRIPTION
## Summary
- fix the pybind11 binding for multiply_to_security_if_negative

## Testing
- `cmake -S src -B build` *(fails: pybind11/magic_enum not found)*
- `cmake --build build` *(fails: no Makefile)*

------
https://chatgpt.com/codex/tasks/task_e_6858a89826008332846d3eb2974e5843